### PR TITLE
Address Validation

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeShipwire::AddressDecorator
+  def self.prepended(klass)
+    klass.before_validation :clear_remote_error
+  end
+
+private
+  def clear_remote_error
+    address_changed = address1_changed? || address2_changed? || city_changed? || state_id_changed? || state_name_changed? || country_id_changed? || zipcode_changed?
+
+    self.remote_validation_error = nil if address_changed && !remote_validation_error_changed?
+  end
+end
+
+Spree::Address.prepend(SpreeShipwire::AddressDecorator)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeShipwire::OrderDecorator
+  def self.prepended(klass)
+    klass.validate :validate_remote_ship_address_error
+  end
+
+private
+  def validate_remote_ship_address_error
+    error = ship_address.try(:remote_validation_error)
+
+    errors.add(:base, error) if error.present?
+  end
+end
+
+Spree::Order.prepend(SpreeShipwire::OrderDecorator)

--- a/db/migrate/20150419190027_add_validation_error_to_spree_addresses.rb
+++ b/db/migrate/20150419190027_add_validation_error_to_spree_addresses.rb
@@ -1,0 +1,5 @@
+class AddValidationErrorToSpreeAddresses < ActiveRecord::Migration
+  def change
+    add_column :spree_addresses, :remote_validation_error, :string
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Address do
+  it "clears remote error when address changed" do
+    address = create(:address)
+
+    expect(address.remote_validation_error).to be_nil
+
+    address.update(remote_validation_error: 'oops')
+
+    expect(address.remote_validation_error).to eq('oops')
+
+    address.address1 = '123 Main St.'
+    address.save
+
+    expect(address.remote_validation_error).to be_nil
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Spree::Order do
+  it "checks if ship address has remote errors" do
+    order = create(:order_with_line_items)
+
+    expect(order).to be_valid
+
+    order.ship_address.update(remote_validation_error: 'whoops')
+
+    expect(order).to_not be_valid
+  end
+end

--- a/spec/models/stock_estimator_spec.rb
+++ b/spec/models/stock_estimator_spec.rb
@@ -62,5 +62,14 @@ describe Spree::Stock::Estimator do
       expect(rate.shipping_method).to_not be_nil
       expect(rate.shipping_method.name).to eq('FedEx CrazyFast')
     end
+
+    it "catches address errors" do
+      expect(SpreeShipwire::Rates).to receive(:compute)
+                                        .and_raise(SpreeShipwire::AddressError.new('Invalid address'))
+
+      estimator.shipping_rates(package)
+
+      expect(order.ship_address.remote_validation_error).to eq('Invalid address')
+    end
   end
 end


### PR DESCRIPTION
When shipping rates are computed, Shipwire will validate the address and return a warning "Cannot verify shipping address".

When that happens, the `order.ship_address.remote_validation_error` is set, causing the order to become invalid and thus blocking the checkout from moving to the next step.
